### PR TITLE
Feature/menu popover

### DIFF
--- a/src/assets/images/blackXIcon.svg
+++ b/src/assets/images/blackXIcon.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19.3334 4.5L4.5 19.3334M4.5 4.5L19.3334 19.3334L4.5 4.5Z" stroke="black" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,6 +1,6 @@
 import styles from "./Dropdown.module.scss";
 import dropdownIcon from "../../assets/images/dropdownArrowIcon.svg";
-import { FC, useEffect, useRef, useState } from "react";
+import { FC, useState } from "react";
 import RatingContainer from "../RatingContainer/RatingContainer";
 interface DropDownProps {
   filterTitle: string;
@@ -20,7 +20,6 @@ const Dropdown: FC<DropDownProps> = (props) => {
     false,
     false,
   ]);
-  const ratingPopoverRef = useRef<HTMLDivElement | null>(null);
 
   const hasAtLeastOneTrue = (booleanArray: boolean[]) => {
     return booleanArray.some((value) => value);

--- a/src/components/MenuPopover/MenuPopover.module.scss
+++ b/src/components/MenuPopover/MenuPopover.module.scss
@@ -1,0 +1,41 @@
+@import "../../styles/constants.module.scss";
+@import "../../styles/mediaQueries.scss";
+
+.MenuPopoverLayout {
+  display: flex;
+  flex-flow: column;
+  justify-content: flex-start;
+  align-items: center;
+  width: 100%;
+  box-shadow: 2px 4px 10px 0px rgba(175, 175, 175, 0.25);
+  border-bottom: 1px solid rgba(242, 242, 242, 1);
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: white;
+
+  .xBtnContainer {
+    display: flex;
+    flex-flow: row;
+    justify-content: flex-start;
+    align-items: center;
+    width: $mobile-view-width;
+    height: 46px;
+  }
+
+  .buttonsContainer {
+    display: flex;
+    flex-flow: column;
+    justify-content: flex-start;
+    align-items: flex-start;
+    gap: 24px;
+    width: $mobile-view-width;
+    padding: 40px 0;
+
+    .menuBtn {
+      font-size: 18px;
+      line-height: 22px;
+      letter-spacing: 1.9199999570846558px;
+    }
+  }
+}

--- a/src/components/MenuPopover/MenuPopover.tsx
+++ b/src/components/MenuPopover/MenuPopover.tsx
@@ -1,0 +1,50 @@
+import { NavLink } from "react-router-dom";
+import styles from "./MenuPopover.module.scss";
+import { UIConstants, appRoutes } from "../../shared/constants";
+import Footer from "../Footer/Footer";
+import blackXIcon from "../../assets/images/blackXIcon.svg";
+import { FC, useEffect } from "react";
+import useGetScreenWidth from "../../hooks/useGetWidthScreen";
+
+interface MenuPopoverProps {
+  toggleMenu: () => void;
+}
+
+const MenuPopover: FC<MenuPopoverProps> = (props) => {
+  const screenWidth = useGetScreenWidth();
+  useEffect(() => {
+    const handleScreenSizeChange = () => {
+      if (screenWidth > UIConstants.sizes.tabletWidth) {
+        props.toggleMenu();
+      }
+    };
+    handleScreenSizeChange();
+  }, [screenWidth, props]);
+
+  return (
+    <div className={styles.MenuPopoverLayout}>
+      <div className={styles.xBtnContainer} onClick={() => props.toggleMenu()}>
+        <img src={blackXIcon} alt="black-x-icon" />
+      </div>
+      <div className={styles.buttonsContainer}>
+        <NavLink
+          to={appRoutes.restaurants}
+          className={styles.menuBtn}
+          onClick={() => props.toggleMenu()}
+        >
+          Restaurants
+        </NavLink>
+        <NavLink
+          to={appRoutes.chefs}
+          className={styles.menuBtn}
+          onClick={() => props.toggleMenu()}
+        >
+          Chefs
+        </NavLink>
+      </div>
+      <Footer />
+    </div>
+  );
+};
+
+export default MenuPopover;

--- a/src/components/Navbar/Navbar.module.scss
+++ b/src/components/Navbar/Navbar.module.scss
@@ -8,6 +8,7 @@
   align-items: center;
   width: 100%;
   height: 46px;
+  position: relative;
   @include smallDesktopScreen {
     height: 64px;
   }

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -6,8 +6,14 @@ import signInIcon from "../../assets/images/SignInIcon.svg";
 import bagIcon from "../../assets/images/BagIcon.svg";
 import { NavLink, useNavigate } from "react-router-dom";
 import { appRoutes } from "../../shared/constants";
+import { useState } from "react";
+import MenuPopover from "../MenuPopover/MenuPopover";
 
 function Navbar() {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const toggleMenu = () => {
+    setIsMenuOpen((menuOpen) => !menuOpen);
+  };
   const navigate = useNavigate();
   const handleHomePageNavigation = () => {
     navigate("/");
@@ -17,10 +23,10 @@ function Navbar() {
     <section className={styles.headerSectionLayout}>
       <div className={styles.HeaderContainer}>
         <div className={styles.navbarContainer}>
-          <div className={styles.menuContainer}>
+          <button className={styles.menuContainer} onClick={() => toggleMenu()}>
             <img src={hamburgerIcon} alt="hamburger-icon" />
-          </div>
-          <NavLink to="/" className={styles.logoContainer}>
+          </button>
+          <NavLink to={appRoutes.base} className={styles.logoContainer}>
             <img src={logoIcon} alt="logo" />
           </NavLink>
           <div className={styles.navbarButtonsContainer}>
@@ -60,6 +66,7 @@ function Navbar() {
           </button>
         </div>
       </div>
+      {isMenuOpen ? <MenuPopover toggleMenu={toggleMenu} /> : ""}
     </section>
   );
 }


### PR DESCRIPTION
# Menu Popover Feature Done

## This PR includes
- A mobile menu that links to the pages of restaurants and chefs.
- When the screen grows larger than the tablet size, the popover closes automatically.
- When you click a button in the menu, it closes automatically.

## Notes
- The popover runs over the app's main navbar and uses position abosulte when the main navbar is its relative position.

## Examples

https://github.com/OrenMoveo/Epicure/assets/156906187/f72e59ba-b48b-41d3-a040-3ec919b8f2ac


